### PR TITLE
Add "Screen Resolution" as full screen mode

### DIFF
--- a/Src/BeebEm.rc
+++ b/Src/BeebEm.rc
@@ -534,6 +534,7 @@ BEGIN
         END
         POPUP "DirectX Full Screen Modes"
         BEGIN
+            MENUITEM "Current Screen Resolution",   ID_VIEW_DD_SCREENRES
             MENUITEM "640x480",                     ID_VIEW_DD_640X480
             MENUITEM "720x576",                     ID_VIEW_DD_720X576
             MENUITEM "800x600",                     ID_VIEW_DD_800X600

--- a/Src/beebemrc.h
+++ b/Src/beebemrc.h
@@ -273,6 +273,7 @@ Boston, MA  02110-1301, USA.
 #define ID_VIEW_DD_640X480              40099
 #define ID_VIEW_DD_1024X768             40100
 #define ID_VIEW_DD_1280X1024            40101
+#define ID_VIEW_DD_SCREENRES            40102
 #define ID_FILE_RESET                   40103
 #define ID_MODELB                       40105
 #define ID_MASTER128                    40106

--- a/Src/beebwin.cpp
+++ b/Src/beebwin.cpp
@@ -780,6 +780,7 @@ void BeebWin::InitMenu(void)
 	//CheckMenuItem(hMenu, m_MenuIdWinSize, MF_CHECKED);
 
 	// View -> DD mode
+	CheckMenuItem(hMenu, ID_VIEW_DD_SCREENRES, MF_UNCHECKED);
 	CheckMenuItem(hMenu, ID_VIEW_DD_640X480, MF_UNCHECKED);
 	CheckMenuItem(hMenu, ID_VIEW_DD_720X576, MF_UNCHECKED);
 	CheckMenuItem(hMenu, ID_VIEW_DD_800X600, MF_UNCHECKED);
@@ -1820,6 +1821,11 @@ void BeebWin::TranslateDDSize(void)
 		m_XDXSize = 1920;
 		m_YDXSize = 1080;
 		break;
+	case ID_VIEW_DD_SCREENRES:
+		// Pixel size of default monitor
+		m_XDXSize = GetSystemMetrics(SM_CXSCREEN);
+		m_YDXSize = GetSystemMetrics(SM_CYSCREEN);
+		break;
 	}
 }
 	
@@ -2763,6 +2769,7 @@ void BeebWin::HandleCommand(int MenuId)
 		}
 		break;
 
+	case ID_VIEW_DD_SCREENRES:
 	case ID_VIEW_DD_640X480:
 	case ID_VIEW_DD_720X576:
 	case ID_VIEW_DD_800X600:
@@ -2774,6 +2781,8 @@ void BeebWin::HandleCommand(int MenuId)
 	case ID_VIEW_DD_1440X900:
 	case ID_VIEW_DD_1600X1200:
 	case ID_VIEW_DD_1920X1080:
+		// Ignore ID_VIEW_DD_SCREENRES if already in full screen mode
+		if ((MenuId != ID_VIEW_DD_SCREENRES) || !m_isFullScreen)
 		{
 			CheckMenuItem(hMenu, m_DDFullScreenMode, MF_UNCHECKED);
 			m_DDFullScreenMode = MenuId;


### PR DESCRIPTION
My laptop has an unsupported 1366x768 screen and people have [suggested full screen support](http://stardot.org.uk/forums/viewtopic.php?f=53&t=12583&p=161100&hilit=beebem+directx#p161100) for other modes.

This commit has a simple "View | DirectX Full Screen Modes | Screen Resolution" option which simply uses the current resolution when you switch to full screen.  It does nothing if you select it while in a full screen mode.  It doesn't aim for multiple monitor support, but I don't think beebem does anyway.

"Screen Resolution" isn't a great name, but I can't think of a better one.