### PR TITLE
Bug video capture

### DIFF
--- a/Src/avi.cpp
+++ b/Src/avi.cpp
@@ -77,24 +77,6 @@ HRESULT AVIWriter::Initialise(const CHAR *pszFileName,
 		hr = AVIFileCreateStream(m_pAVIFile, &m_pAudioStream, &StreamInfo);
 	}
 
-	//if (SUCCEEDED(hr) && WaveFormat)
-	//{
-	//	memset(&opts, 0, sizeof(AVICOMPRESSOPTIONS));
-	//	opts.fccType = streamtypeAUDIO;
-	//	opts.fccHandler = 0;
-	//	opts.dwKeyFrameEvery = 0;
-	//	opts.dwQuality = 0;
-	//	opts.dwBytesPerSecond = 0;
-	//	opts.dwFlags = 0;
-	//	opts.lpFormat = &m_WaveFormat;
-	//	opts.cbFormat = sizeof(WAVEFORMATEX);
-	//	opts.lpParms = 0;
-	//	opts.cbParms = 0;
-	//	opts.dwInterleaveEvery = 0;
-	//
-	//	hr = AVIMakeCompressedStream(&m_pCompressedAudioStream, m_pAudioStream, &opts, NULL);
-	//}
-
 	if (SUCCEEDED(hr) && WaveFormat)
 	{
 		hr = AVIStreamSetFormat(m_pAudioStream,
@@ -121,31 +103,6 @@ HRESULT AVIWriter::Initialise(const CHAR *pszFileName,
 		
 		hr = AVIFileCreateStream(m_pAVIFile, &m_pVideoStream, &StreamInfo);
 	}
-
-	/*if (SUCCEEDED(hr))
-	{
-		memset(&opts, 0, sizeof(AVICOMPRESSOPTIONS));
-		opts.fccType = streamtypeVIDEO;
-		opts.fccHandler = mmioFOURCC('m', 'r', 'l', 'e'); // Microsoft RLE
-		//opts.fccHandler = mmioFOURCC('m', 's', 'v', 'c'); // Microsoft Video 1
-		opts.dwKeyFrameEvery = 100;
-		opts.dwQuality = 0;
-		opts.dwBytesPerSecond = 0;
-		opts.dwFlags = AVICOMPRESSF_KEYFRAMES;
-		opts.lpFormat = 0;
-		opts.cbFormat = 0;
-		opts.lpParms = 0;
-		opts.cbParms = 0;
-		opts.dwInterleaveEvery = 0;
-
-		//AVICOMPRESSOPTIONS *aopts[1];
-		//aopts[0]=&opts;
-		//AVISaveOptions(hWnd, 0, 1, &m_pVideoStream, aopts);
-
-		hr = AVIMakeCompressedStream(&m_pCompressedVideoStream, m_pVideoStream, &opts, NULL);
-
-		//AVISaveOptionsFree(1,aopts);
-	}*/
 
 	bmiData outputData = m_BitmapFormat;
 	outputData.bmiHeader.biCompression = BI_RLE8;
@@ -223,12 +180,6 @@ void AVIWriter::Close()
 		ICClose(m_videoCompressor);
 		m_videoCompressor = NULL;
 	}
-
-	/*if (NULL != m_pCompressedVideoStream)
-	{
-		AVIStreamRelease(m_pCompressedVideoStream);
-		m_pCompressedVideoStream = NULL;
-	}*/
 
 	if (NULL != m_pVideoStream)
 	{

--- a/Src/avi.h
+++ b/Src/avi.h
@@ -54,7 +54,10 @@ private:
 	LONG m_nSampleSize;
 
 	bmiData m_BitmapFormat;
+	BITMAPINFOHEADER m_BitmapOutputFormat;
 	PAVISTREAM m_pVideoStream;
-	PAVISTREAM m_pCompressedVideoStream;
+	HIC m_videoCompressor;
+	LPVOID m_videoBuffer;
+	int m_videoBufferSize;
 	LONG m_nFrame;
 };

--- a/Src/avi.h
+++ b/Src/avi.h
@@ -58,6 +58,7 @@ private:
 	PAVISTREAM m_pVideoStream;
 	HIC m_videoCompressor;
 	LPVOID m_videoBuffer;
+	LPVOID m_lastVideoFrame;
 	int m_videoBufferSize;
 	LONG m_nFrame;
 };


### PR DESCRIPTION
I found someone else had hit exactly the [same problem with Video for Windows](http://stackoverflow.com/questions/22765194/is-it-possible-to-encode-using-the-mrle-codec-on-video-for-windows-under-windows).  Their problem appeared in Windows 8, hence the title of the penultimate commit.

No-one has mentioned this problem in beebem so I did wonder if we were both suffering from an environmental difficulty, but @chrisn has reproduced it so it seems to be widespread.

I took the suggestion in one of the [comments on that question](http://stackoverflow.com/questions/22765194/is-it-possible-to-encode-using-the-mrle-codec-on-video-for-windows-under-windows#comment34708055_22765194) to replace AVIMakeCompressedStream with a call to ICOpen to get direct access to the compressor, and this worked.  ICOpen is an ancient API so this should also work on older versions of Windows, but I have no way of testing it.

The second commit adds support for P-frames (frames that depend on previous frames), which greatly improves the compression.