### PR TITLE
Show teletext graphics hold character in old colour

### DIFF
--- a/Src/video.cpp
+++ b/Src/video.cpp
@@ -717,6 +717,8 @@ static void DoMode7Row(void) {
   unsigned int tmp;
 
   unsigned int Foreground=mainWin->cols[7];
+  /* The foreground colour changes after the current character; only relevant for hold graphics */
+  unsigned int ForegroundPending=Foreground;
   unsigned int ActualForeground;
   unsigned int Background=mainWin->cols[0];
   int Flash=0; /* i.e. steady */
@@ -753,7 +755,7 @@ static void DoMode7Row(void) {
         case 133:
         case 134:
         case 135:
-          Foreground=mainWin->cols[byte-128];
+          ForegroundPending=mainWin->cols[byte-128];
           Graphics=0;
           break;
 
@@ -781,7 +783,7 @@ static void DoMode7Row(void) {
         case 149:
         case 150:
         case 151:
-          Foreground=mainWin->cols[byte-144];
+          ForegroundPending=mainWin->cols[byte-144];
           Graphics=1;
           break;
 
@@ -884,6 +886,7 @@ static void DoMode7Row(void) {
       }; /* Pixel within byte */
       Mode7DoubleHeightFlags[CurrentChar]^=1; /* Not double height - so if the next line is double height it will be top half */
     }
+	Foreground=ForegroundPending;
   }; /* character loop */
 
   /* Finish off right bits of scan line */


### PR DESCRIPTION
When graphics hold is enabled, colour control codes are displayed as the
last graphics character rather than the usual blank. They should be
displayed in the previous colour, not the colour being selected by the
control code.

e.g. This should produce equal width red and blue lines:

PRINTCHR$(158);CHR$(145);",";CHR$(148);",,"

This change fixes this [Revs bug](http://www.stardot.org.uk/forums/viewtopic.php?p=179131&sid=a91c9b5da209bb47aa006c145dbf7ed4#p179131) and this [Oxygene bug](https://github.com/stardot/beebem-windows/pull/19#issuecomment-305983527).