### PR TITLE
Emulation pausing and boot delay features

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,9 +32,9 @@ Richard Broadhurst, J.G.Harston, Mike Wyatt, Alistair Cree, Steve Insley)
 * General sound emulation improvements.
 * Fixed graphics hold in teletext mode.
 * Release Shift key on disk read after auto-booting.
-* Added AutoBootDelay CLI argument taking a delay parameter set in 
+* Added AutoBootDelay CLI argument taking a delay parameter set in
   milliseconds creates a delay between initial boot and auto-boot of disk image
-  if supplied in arguments.  If used with -StartPaused, timer starts after
+  if supplied in arguments. If used with -StartPaused, timer starts after
   un-pausing
 * Added ability to pause the emulation, distinct from freezing when focus lost.
   - Menu item on Speed menu.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@ BeebEm Change History
 =====================
 
 Version 4.15 (Charles Reilly, Chris Needham, Kieran Mockford, pstnotpd,
-Richard Broadhurst, J.G.Harston, Mike Wyatt, Alistair Cree)
+Richard Broadhurst, J.G.Harston, Mike Wyatt, Alistair Cree, Steve Insley)
 ------------
 * Fixed 320x256 screen capture.
 * Enabled DirectX full screen display at current desktop screen resolution.
@@ -32,6 +32,18 @@ Richard Broadhurst, J.G.Harston, Mike Wyatt, Alistair Cree)
 * General sound emulation improvements.
 * Fixed graphics hold in teletext mode.
 * Release Shift key on disk read after auto-booting.
+* Added AutoBootDelay CLI argument taking a delay parameter set in 
+  milliseconds creates a delay between initial boot and auto-boot of disk image
+  if supplied in arguments.  If used with -StartPaused, timer starts after
+  un-pausing
+* Added ability to pause the emulation, distinct from freezing when focus lost.
+  - Menu item on Speed menu.
+  - Alt+F5 will pause/unpause.
+  - StartPaused CLI argument can be used to prevent the emulation from starting
+    until unpaused.  Implemented to better support HyperSpin/RocketLauncher
+	configurations where you want to defer boot until the BeebEm window and
+	bezels are shown, and any Fade screen has been removed.
+  - If in windowed mode and showing fps, pause state is shown in window title.
 
 Version 4.14 (J.G.Harston, Steve Pick, Mike Wyatt)
 ------------

--- a/Help/commandline.html
+++ b/Help/commandline.html
@@ -206,15 +206,16 @@ option.</p>
 
 <p>-StartPaused is useful if you are scripting the launch of BeebEm and you
 want to manipulate the window, its position or perform other tasks before
-the emulated machine boots.  In this kind of script, launch BeebEm, then 
-send a message to the BeebEm window with wParam = 40293.  E.g. if using
+the emulated machine boots. In this kind of script, launch BeebEm, then
+send an Alt+F5 keypress when you are ready to un-pause. E.g., if using
 AutoHotKey, including the following in your script will toggle the pause
 state:</p>
-<p><blockquote><pre>PostMessage, 0x111, 40293,,,ahk_class BEEBWIN</pre></blockquote></p>
+
+<blockquote><code>SendInput !{F5}</code></blockquote>
 
 <p>If -StartPaused is used, the timer for -AutoBootDelay will start after
-unpausing, but will continue if paused again.  If the timer expires while
-paused, the boot will occur immediately after unpausing for the second time.</p>
+unpausing, but will reset if paused again. The -KbdCmd option will also
+only apply when the emulator is unpaused for the first time.</p>
 
 <h2>Startup Key Sequence</h2>
 
@@ -278,11 +279,13 @@ The string can include the following key sequences:</p>
       presses.</td>
   </tr>
 </table>
-                 
+
 <p>So, for example, run a tape image using commands such as:</p>
 
-<p>BeebEm -KbdCmd "OSCLI\s2\STAPE\s2\S\nPAGE=3584\nCH.\s22\S\n" test.uef</p>
-<p>BeebEm -KbdCmd "OSCLI\s2\STAPE\s2\S\nOSCLI\s2\SRUN\s2\S\n" game.uef</p>
+<blockquote>
+  <p><code>BeebEm -KbdCmd "OSCLI\s2\STAPE\s2\S\nPAGE=3584\nCH.\s22\S\n" test.uef</code></p>
+  <p><code>BeebEm -KbdCmd "OSCLI\s2\STAPE\s2\S\nOSCLI\s2\SRUN\s2\S\n" game.uef</code></p>
+</blockquote>
 
       <!-- End of content -->
       </td>

--- a/Help/commandline.html
+++ b/Help/commandline.html
@@ -109,6 +109,16 @@
   </tr>
 
   <tr>
+      <td width="20%">-AutoBootDelay &lt;milliseconds&gt;</td>
+      <td width="80%">Sets a delay between initial boot and Shift+Break to boot disk if disk image file specified</td>
+  </tr>
+
+  <tr>
+      <td width="20%">-StartPaused</td>
+      <td width="80%">Starts BeebEm with the emulation paused.  Other boot actions occur after emulation is unpaused.</td>
+  </tr>
+
+  <tr>
     <td width="20%">-DebugScript &lt;file&gt;</td>
     <td width="80%">Open debugger and execute the commands</td>
   </tr>
@@ -193,6 +203,18 @@ can include the full path or it can just be the name of a file in the
 loaded.  The name can include the full path or it can just be the name of a
 file in the 'Tapes' directory.  To run the tape image use the -KbdCmd
 option.</p>
+
+<p>-StartPaused is useful if you are scripting the launch of BeebEm and you
+want to manipulate the window, its position or perform other tasks before
+the emulated machine boots.  In this kind of script, launch BeebEm, then 
+send a message to the BeebEm window with wParam = 40293.  E.g. if using
+AutoHotKey, including the following in your script will toggle the pause
+state:</p>
+<p><blockquote><pre>PostMessage, 0x111, 40293,,,ahk_class BEEBWIN</pre></blockquote></p>
+
+<p>If -StartPaused is used, the timer for -AutoBootDelay will start after
+unpausing, but will continue if paused again.  If the timer expires while
+paused, the boot will occur immediately after unpausing for the second time.</p>
 
 <h2>Startup Key Sequence</h2>
 

--- a/Help/index.html
+++ b/Help/index.html
@@ -106,6 +106,7 @@
 <li>Kieran Mockford</li>
 <li>pstnotpd</li>
 <li>Richard Broadhurst</li>
+<li>Steve Insley</li>
 </ul>
 
 <p>Thanks also to Jordon Russell Software for the excellent 

--- a/Help/keyboard.html
+++ b/Help/keyboard.html
@@ -184,6 +184,10 @@ these are not:</p>
     <td width="50%" align="center">ALT F4</td>
     <td width="50%" align="center">Exit</td>
   </tr>
+  <tr>
+      <td width="50%" align="center">ALT F5</td>
+      <td width="50%" align="center">Pause/unpause emulation.</td>
+  </tr>
 </table>
 
 <h2>Custom Key Mappings</h2>

--- a/Help/menus.html
+++ b/Help/menus.html
@@ -417,6 +417,13 @@
       rate the faster BeebEm runs relative to a BBC Micro.
     </td>
   </tr>
+
+  <tr>
+      <td width="20%">Pause Emulation</td>
+      <td width="80%">
+          Pauses the emulation.
+      </td>
+  </tr>
 </table>
 
 <h2>Sound Menu</h2>

--- a/Src/BeebEm.rc
+++ b/Src/BeebEm.rc
@@ -599,6 +599,8 @@ BEGIN
         MENUITEM "10 FPS",                      IDM_10FPS
         MENUITEM "5 FPS",                       IDM_5FPS
         MENUITEM "1 FPS",                       IDM_1FPS
+        MENUITEM SEPARATOR
+        MENUITEM "&Pause Emulation",            IDM_EMUPAUSED
     END
     POPUP "&Sound"
     BEGIN

--- a/Src/beebemrc.h
+++ b/Src/beebemrc.h
@@ -425,6 +425,7 @@ Boston, MA  02110-1301, USA.
 #define ID_VIEW_DD_1280X720             40288
 #define ID_VIEW_DD_1920X1080            40289
 #define IDM_ARMCOPRO                    40290
+#define IDM_EMUPAUSED                   40293 // Must not be changed to maintain support for external messaging
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -433,7 +434,7 @@ Boston, MA  02110-1301, USA.
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        117
-#define _APS_NEXT_COMMAND_VALUE         40291
+#define _APS_NEXT_COMMAND_VALUE         40294
 #define _APS_NEXT_CONTROL_VALUE         1087
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/Src/beebemrc.h
+++ b/Src/beebemrc.h
@@ -425,7 +425,7 @@ Boston, MA  02110-1301, USA.
 #define ID_VIEW_DD_1280X720             40288
 #define ID_VIEW_DD_1920X1080            40289
 #define IDM_ARMCOPRO                    40290
-#define IDM_EMUPAUSED                   40293 // Must not be changed to maintain support for external messaging
+#define IDM_EMUPAUSED                   40293
 #define IDC_STATIC                      -1
 
 // Next default values for new objects

--- a/Src/beebwin.h
+++ b/Src/beebwin.h
@@ -246,6 +246,8 @@ public:
 	int PasteKey(int addr);
 	void CaptureBitmapPending(bool autoFilename);
 	void DoShiftBreak();
+	bool HasKbdCmd() const;
+	void SetKeyboardTimer();
 	void SetBootDiscTimer();
 	void KillBootDiscTimer();
 
@@ -375,6 +377,8 @@ public:
 	bool		m_EmuPaused;
 	bool		m_StartPaused;
 	bool		m_AutoBootDisc;
+	bool		m_KeyboardTimerElapsed;
+	bool		m_BootDiscTimerElapsed;
 	unsigned char RomWritePrefs[16];
 
 	// Bitmap capture vars

--- a/Src/beebwin.h
+++ b/Src/beebwin.h
@@ -245,9 +245,9 @@ public:
 	void CopyKey(int data);
 	int PasteKey(int addr);
 	void CaptureBitmapPending(bool autoFilename);
-	void DoShiftBreak(void);
-	void SetBootDiscTimer(void);
-	void KillBootDiscTimer(void);
+	void DoShiftBreak();
+	void SetBootDiscTimer();
+	void KillBootDiscTimer();
 
 	void SaveEmuUEF(FILE *SUEF);
 	void LoadEmuUEF(FILE *SUEF,int Version);
@@ -372,8 +372,9 @@ public:
 	int		m_KbdCmdLastCycles;
 	bool		m_NoAutoBoot;
 	int		m_AutoBootDelay;
-	bool            m_EmuPaused;
-	bool	m_AutoBootDisc;
+	bool		m_EmuPaused;
+	bool		m_StartPaused;
+	bool		m_AutoBootDisc;
 	unsigned char RomWritePrefs[16];
 
 	// Bitmap capture vars

--- a/Src/beebwin.h
+++ b/Src/beebwin.h
@@ -210,6 +210,7 @@ public:
 	void WinSizeChange(int size, int width, int height);
 	void WinPosChange(int x, int y);
 	bool IsFrozen();
+	bool IsPaused();
 	void ShowMenu(bool on);
 	void HideMenu(bool hide);
 	void TrackPopupMenu(int x, int y);
@@ -244,6 +245,9 @@ public:
 	void CopyKey(int data);
 	int PasteKey(int addr);
 	void CaptureBitmapPending(bool autoFilename);
+	void DoShiftBreak(void);
+	void SetBootDiscTimer(void);
+	void KillBootDiscTimer(void);
 
 	void SaveEmuUEF(FILE *SUEF);
 	void LoadEmuUEF(FILE *SUEF,int Version);
@@ -367,6 +371,9 @@ public:
 	int		m_KbdCmdDelay;
 	int		m_KbdCmdLastCycles;
 	bool		m_NoAutoBoot;
+	int		m_AutoBootDelay;
+	bool            m_EmuPaused;
+	bool	m_AutoBootDisc;
 	unsigned char RomWritePrefs[16];
 
 	// Bitmap capture vars

--- a/Src/beebwindx.cpp
+++ b/Src/beebwindx.cpp
@@ -782,7 +782,10 @@ void BeebWin::DisplayClientAreaText(HDC hdc)
 	if (m_ShowSpeedAndFPS && m_isFullScreen)
 	{
 		char fps[50];
-		sprintf(fps, "%2.2f %2d", m_RelativeSpeed, (int)m_FramesPerSecond);
+		if (!m_EmuPaused)
+			sprintf(fps, "%2.2f %2d", m_RelativeSpeed, (int)m_FramesPerSecond);
+		else
+			sprintf(fps, "Paused");
 		SetBkMode(hdc,TRANSPARENT);
 		SetTextColor(hdc,0x808080);
 		TextOut(hdc, TeletextEnabled ? 490 : 580, TextStart, fps, (int)strlen(fps));

--- a/Src/main.cpp
+++ b/Src/main.cpp
@@ -53,42 +53,6 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE /* hPrevInstance */,
 	// Create serial threads
 	SerialInit();
 
-	// Loop while 
-	do
-	{
-		if (PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE) || mainWin->IsFrozen())
-		{
-			if (!GetMessage(&msg,   // message structure
-				NULL,   // handle of window receiving the message
-				0,      // lowest message to examine
-				0))
-				break; // Quit the app on WM_QUIT
-
-			if (hCurrentAccelTable != NULL)
-			{
-				TranslateAccelerator(hCurrentDialog, hCurrentAccelTable, &msg);
-			}
-
-			if (hCurrentDialog == NULL || !IsDialogMessage(hCurrentDialog, &msg)) {
-				TranslateMessage(&msg);// Translates virtual key codes
-				DispatchMessage(&msg); // Dispatches message to window
-			}
-		}
-	} while (mainWin->IsPaused());
-
-	/*  Processing of post-power-on actions moved from being set up in-line with
-	 *  checks to after all initialisation completes to allow for the case where
-	 *  BeebEm starts with the emulation paused.
-	 */
-
-	// Schedule first key press if keyboard command supplied
-	if (mainWin->m_KbdCmd[0] != 0)
-		SetTimer(mainWin->m_hWnd, 1, 1000, NULL);
-
-	// If command line file in state to boot, trigger the timer
-	if (mainWin->m_AutoBootDisc)
-		mainWin->SetBootDiscTimer();
-
 	do
 	{
 		if (PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE) || mainWin->IsFrozen())


### PR DESCRIPTION
* Added AutoBootDelay CLI argument taking a delay parameter set in 
  milliseconds creates a delay between initial boot and auto-boot of disk image
  if supplied in arguments.  If used with -StartPaused, timer starts after
  un-pausing
* Added ability to pause the emulation, distinct from freezing when focus lost.
  - Menu item on Speed menu.
  - Alt+F5 will pause/unpause.
  - StartPaused CLI argument can be used to prevent the emulation from starting
    until unpaused.  Implemented to better support HyperSpin/RocketLauncher
	configurations where you want to defer boot until the BeebEm window and
	bezels are shown, and any Fade screen has been removed.
  - If in windowed mode and showing fps, pause state is shown in window title.

Documentation updated to reflect new features.  I also took the liberty of adding a credit to the Index page.  :-)

NOTES:  Perhaps not the cleanest code, but I was aiming to implement the features with the minimal amount of structural changes overall to make merging simpler.  Also because of that, I did not implement the change to show "Paused" instead of fps data when in full-screen as I could not achieve this without major changes.  Perhaps someone that is more of a C++ ninja than me could do that if anyone cares?!

I added a comment to the beebemrc header file to warn that the #define IDM_EMUPAUSED value should not be changed.  This is to prevent breaking scripts that users may develop that toggle the pause state by sending a WM_COMMAND message to the BeebEm window directly with the wParam value 40293.

An example of the effect that can be achieved with RocketLauncher/HyperSpin now that I have implemented these features can be seen [here](https://www.youtube.com/watch?v=6yA04ca0Bk4).  Note  that without the use of -StartPaused and a subsequent message being sent to the BeebEm window to unpause, the machine would boot too quickly (i.e. before the window is positioned, the bezel drawn and the "now loading" screen removed) and thus you would miss the loading screen of the game ...  and the charm of seeing the OS prompt during the "buurrrr-beep!".