### PR TITLE
WIP: Assigning Joystick to BBC Keyboard

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -60,6 +60,7 @@ Ken Lowe, Dominic Beesley)
 * Fixed BCD mode in ADC and SBC instructions.
 * Fixed key selection dialog box layout for Windows 10.
 * Added -DebugLabels command line option to load BeebAsm compatible debug labels.
+* Added PC joystick to BBC keyboard mapping.
 
 Version 4.14 (J.G.Harston, Steve Pick, Mike Wyatt)
 ------------

--- a/Documents/KeyMapInfo.txt
+++ b/Documents/KeyMapInfo.txt
@@ -270,3 +270,67 @@ Data for default key mapping:
 -9 0 0 -9 0 1 
 -9 0 0 -9 0 1 
 -9 0 0 -9 0 1 // 255
+-9 0 0 -9 0 1 // 256 - Joystick 1 Up
+-9 0 0 -9 0 1 // Joystick 1 Down
+-9 0 0 -9 0 1 // Joystick 1 Left
+-9 0 0 -9 0 1 // Joystick 1 Right
+-9 0 0 -9 0 1 // Joystick 1 Axis 3 - (Z-)
+-9 0 0 -9 0 1 // Joystick 1 Axis 3 + (Z+)
+-9 0 0 -9 0 1 // Joystick 1 Axis 4 - (R-)
+-9 0 0 -9 0 1 // Joystick 1 Axis 4 + (R+)
+-9 0 0 -9 0 1 // Joystick 1 Axis 5 - (U-)
+-9 0 0 -9 0 1 // Joystick 1 Axis 5 + (U+)
+-9 0 0 -9 0 1 // Joystick 1 Axis 6 - (V-)
+-9 0 0 -9 0 1 // Joystick 1 Axis 6 + (V+)
+-9 0 0 -9 0 1 // Joystick 1 Axis 7 - (Hat Up)
+-9 0 0 -9 0 1 // Joystick 1 Axis 7 + (Hat Down)
+-9 0 0 -9 0 1 // Joystick 1 Axis 8 - (Hat Left)
+-9 0 0 -9 0 1 // Joystick 1 Axis 8 + (Hat Right)
+-9 0 0 -9 0 1 // 272 - Joystick 1 Button 1
+-9 0 0 -9 0 1 // Joystick 1 Button 2
+-9 0 0 -9 0 1 // Joystick 1 Button 3
+-9 0 0 -9 0 1 // Joystick 1 Button 4
+-9 0 0 -9 0 1 // Joystick 1 Button 5
+-9 0 0 -9 0 1 // Joystick 1 Button 6
+-9 0 0 -9 0 1 // Joystick 1 Button 7
+-9 0 0 -9 0 1 // Joystick 1 Button 8
+-9 0 0 -9 0 1 // Joystick 1 Button 9
+-9 0 0 -9 0 1 // Joystick 1 Button 10
+-9 0 0 -9 0 1 // Joystick 1 Button 11
+-9 0 0 -9 0 1 // Joystick 1 Button 12
+-9 0 0 -9 0 1 // Joystick 1 Button 13
+-9 0 0 -9 0 1 // Joystick 1 Button 14
+-9 0 0 -9 0 1 // Joystick 1 Button 15
+-9 0 0 -9 0 1 // Joystick 1 Button 16
+-9 0 0 -9 0 1 // 288 - Joystick 2 Up
+-9 0 0 -9 0 1 // Joystick 2 Down
+-9 0 0 -9 0 1 // Joystick 2 Left
+-9 0 0 -9 0 1 // Joystick 2 Right
+-9 0 0 -9 0 1 // Joystick 2 Axis 3 - (Z-)
+-9 0 0 -9 0 1 // Joystick 2 Axis 3 + (Z+)
+-9 0 0 -9 0 1 // Joystick 2 Axis 4 - (R-)
+-9 0 0 -9 0 1 // Joystick 2 Axis 4 + (R+)
+-9 0 0 -9 0 1 // Joystick 2 Axis 5 - (U-)
+-9 0 0 -9 0 1 // Joystick 2 Axis 5 + (U+)
+-9 0 0 -9 0 1 // Joystick 2 Axis 6 - (V-)
+-9 0 0 -9 0 1 // Joystick 2 Axis 6 + (V+)
+-9 0 0 -9 0 1 // Joystick 2 Axis 7 - (Hat Up)
+-9 0 0 -9 0 1 // Joystick 2 Axis 7 + (Hat Down)
+-9 0 0 -9 0 1 // Joystick 2 Axis 8 - (Hat Left)
+-9 0 0 -9 0 1 // Joystick 2 Axis 8 + (Hat Right)
+-9 0 0 -9 0 1 // 304 - Joystick 2 Button 1
+-9 0 0 -9 0 1 // Joystick 2 Button 2
+-9 0 0 -9 0 1 // Joystick 2 Button 3
+-9 0 0 -9 0 1 // Joystick 2 Button 4
+-9 0 0 -9 0 1 // Joystick 2 Button 5
+-9 0 0 -9 0 1 // Joystick 2 Button 6
+-9 0 0 -9 0 1 // Joystick 2 Button 7
+-9 0 0 -9 0 1 // Joystick 2 Button 8
+-9 0 0 -9 0 1 // Joystick 2 Button 9
+-9 0 0 -9 0 1 // Joystick 2 Button 10
+-9 0 0 -9 0 1 // Joystick 2 Button 11
+-9 0 0 -9 0 1 // Joystick 2 Button 12
+-9 0 0 -9 0 1 // Joystick 2 Button 13
+-9 0 0 -9 0 1 // Joystick 2 Button 14
+-9 0 0 -9 0 1 // Joystick 2 Button 15
+-9 0 0 -9 0 1 // 319 - Joystick 2 Button 16

--- a/Help/keyboard.html
+++ b/Help/keyboard.html
@@ -233,11 +233,62 @@ BBC one.  Do this as follows:</p>
     or save a new file.</li>
 
 <li>Select your mapping using menu item "Options -> User Defined Mapping".
-	You can also use the "Save Preferences" option to save the default user
-	key mapping file that gets loaded when BeebEm starts up.</li>
+	  You can also use the "Save Preferences" option to save the default user
+	  key mapping file that gets loaded when BeebEm starts up.</li>
 </ol>
 
-      <!-- End of content -->
+<h2>Mappings PC Joystick to BBC Keys</h2>
+
+<p>To enable PC joystick to BBC keys mapping, use menu item "Options ->
+   Joystick To Key Mapping". Most likely you will also need to switch to
+   user defined keyboard mapping using menu item "Option -> User Defined
+   Mapping". This will allow you to use your own PC joystick to BBC keys
+   assignments.</p>
+
+<p>Mapping PC joystick axes and buttons to BBC keys is very similar to
+    mapping PC keys, as described above.  Instead of pressing PC key, press
+    the joystick button or move the joystick in the direction that you want
+    to map to the selected BBC key.  Just make sure that the "Joystick To
+    Key Mapping" option is enabled.</p>
+
+<p>As with PC keys, you can map joystick actions to BBC keys in shifted and
+    unshifted state separately.  The most common scenario is to assign a 
+    joystick action to the same BBC key in both shifted and unshifted state.
+    To do that, just click on the BBC key that you want to map, and move
+    joystick or press button twice - once for unshifted and second time for
+    shifted state.</p>
+
+<p>Additionally, you can assign some joystick button to the SHIFT key itself.
+    This can be exploited to assign one joystick button as a modifier for
+    other joystick actions - useful for games which have a lot of keyboard
+    contols such as Elite.</p>
+
+<p>PC joystick to BBC keyboard mapping is independed from enabling PC joystick
+    acting as BBC joystick.  If you enable both, primary PC joystick axes
+    (primary stick up, down, left and right) and first two buttons are mapped
+    to BBC joystick.  You can map other axes and buttons to BBC keys. You can
+    even map those axes and buttons which are acting as BBC joystick to BBC
+    keys. In that case, the PC joystick action will be seen as both BBC
+    joystick action and BBC key press.</p>
+
+<p>To remove mapping from previously mapped joystick action, click on the
+    'Unassign' button.  It will display small window and wait for the
+    joystick action.  Press the joystick button or move the joystick in the
+    direction that you want to unmap.  The same window will be displayed again,
+    giving you opportunity to unmap the joystick action in both unshifted and
+    shifted state at one go.  You can press 'OK' button at this moment to
+    skip the second unassignment.</p>
+
+<p>Joystick mappings are kept together with keyboard mappings in .kmap files.
+    Once joystick mapping for a game is ready, click menu item "Options ->
+    Save User Key Mapping". Save the mapping in the directory where the disk
+    image is located and with the same name as disk image, but with additional
+    '.kmap' extension. For example, if the game's disk image is 'game.ssd',
+    save the mapping as 'game.ssd.kmap'. Next time you open this image with
+    BeebEm, it will automatically load keyboard and joystick mapping from that
+    mapping file.</p>
+
+         <!-- End of content -->
       </td>
 
       <td width="10%"></td>

--- a/Help/menus.html
+++ b/Help/menus.html
@@ -745,6 +745,13 @@
   </tr>
 
   <tr>
+    <td width="20%">Joystick To Key Mapping</td>
+    <td width="80%">Switch on or off mapping PC joystick to BBC keyboard.
+      See the <a href="keyboard.html">Keyboard Mappings</a> section.
+    </td>
+  </tr>
+
+  <tr>
     <td width="20%">Freeze when inactive</td>
     <td width="80%">When selected BeebEm will freeze when you switch
       to another Window.

--- a/Src/BeebEm.rc
+++ b/Src/BeebEm.rc
@@ -108,6 +108,7 @@ BEGIN
     CONTROL         "_ £",IDK_UNDERSCORE,"Button",BS_OWNERDRAW | WS_TABSTOP,269,33,17,14
     CONTROL         "^ ~",IDK_CARET,"Button",BS_OWNERDRAW | WS_TABSTOP,243,19,17,14
     CONTROL         "SFT LK",IDK_SHIFT_LOCK,"Button",BS_OWNERDRAW | WS_TABSTOP,9,62,29,14
+    CONTROL         "Unassign",IDK_UNASSIGN,"Button",BS_OWNERDRAW | WS_TABSTOP,9,101,36,14
 END
 
 IDD_KEYBOARD_LINKS DIALOG  0, 0, 160, 66
@@ -165,7 +166,7 @@ STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_VISIBLE | WS_CAPT
 CAPTION "Press key for unshifted press..."
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    LTEXT           "Assigned to PC key(s):",IDC_STATIC,7,7,74,8
+    LTEXT           "Assigned to PC key(s):",IDC_ASSIGNED_KEYS_LBL,7,7,74,8
     LTEXT           "Static",IDC_ASSIGNED_KEYS,15,21,127,8
     CONTROL         "Shift",IDC_SHIFT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,40,31,10
     PUSHBUTTON      "OK",IDOK,92,39,50,14
@@ -330,9 +331,9 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION VERSION_MAJOR,VERSION_MINOR,0,0
- PRODUCTVERSION VERSION_MAJOR,VERSION_MINOR,0,0
- FILEFLAGSMASK 0x3fL
+FILEVERSION VERSION_MAJOR,VERSION_MINOR,0,0
+PRODUCTVERSION VERSION_MAJOR,VERSION_MINOR,0,0
+FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
 #else
@@ -354,8 +355,8 @@ BEGIN
             VALUE "LegalCopyright", "Copyright © 2009"
             VALUE "OriginalFilename", "BeebEm.exe"
             VALUE "ProductName", "BeebEm"
-            VALUE "ProductVersion", VERSION_STRING
-        END
+			VALUE "ProductVersion", VERSION_STRING
+		END
     END
     BLOCK "VarFileInfo"
     BEGIN
@@ -718,7 +719,7 @@ BEGIN
         MENUITEM "&Joystick",                   IDM_JOYSTICK
         MENUITEM "&Analogue Mousestick",        IDM_AMOUSESTICK
         MENUITEM "&Digital Mousestick",         IDM_DMOUSESTICK
-		MENUITEM "Joystick To Key Mapping"      IDM_JOYSTICK_TO_KEYS
+        MENUITEM "Joystick To Key Mapping",     IDM_JOYSTICK_TO_KEYS
         MENUITEM "&Freeze when inactive",       IDM_FREEZEINACTIVE
         MENUITEM "&Hide Cursor",                IDM_HIDECURSOR
         MENUITEM SEPARATOR
@@ -766,18 +767,18 @@ END
 // TEXTINCLUDE
 //
 
-1 TEXTINCLUDE
+1 TEXTINCLUDE 
 BEGIN
     "beebemrc.h\0"
 END
 
-2 TEXTINCLUDE
+2 TEXTINCLUDE 
 BEGIN
     "#include ""winresrc.h""\r\n"
     "\0"
 END
 
-3 TEXTINCLUDE
+3 TEXTINCLUDE 
 BEGIN
     "\r\n"
     "\0"

--- a/Src/BeebEm.rc
+++ b/Src/BeebEm.rc
@@ -718,6 +718,7 @@ BEGIN
         MENUITEM "&Joystick",                   IDM_JOYSTICK
         MENUITEM "&Analogue Mousestick",        IDM_AMOUSESTICK
         MENUITEM "&Digital Mousestick",         IDM_DMOUSESTICK
+		MENUITEM "Joystick To Key Mapping"      IDM_JOYSTICK_TO_KEYS
         MENUITEM "&Freeze when inactive",       IDM_FREEZEINACTIVE
         MENUITEM "&Hide Cursor",                IDM_HIDECURSOR
         MENUITEM SEPARATOR

--- a/Src/SelectKeyDialog.cpp
+++ b/Src/SelectKeyDialog.cpp
@@ -31,6 +31,7 @@ Boston, MA  02110-1301, USA.
 /****************************************************************************/
 
 static bool IsDlgItemChecked(HWND hDlg, int nIDDlgItem);
+static void DlgItemCheck(HWND hDlg, int nIDDlgItem, bool checked);
 
 SelectKeyDialog* selectKeyDialog;
 
@@ -40,14 +41,15 @@ SelectKeyDialog::SelectKeyDialog(
 	HINSTANCE hInstance,
 	HWND hwndParent,
 	const std::string& Title,
-	const std::string& SelectedKey) :
+	const std::string& SelectedKey,
+	bool doingShifted) :
 	m_hInstance(hInstance),
 	m_hwnd(nullptr),
 	m_hwndParent(hwndParent),
 	m_Title(Title),
 	m_SelectedKey(SelectedKey),
 	m_Key(-1),
-	m_Shift(false)
+	m_Shift(doingShifted)
 {
 }
 
@@ -101,6 +103,11 @@ INT_PTR SelectKeyDialog::DlgProc(
 		SetWindowText(m_hwnd, m_Title.c_str());
 
 		SetDlgItemText(m_hwnd, IDC_ASSIGNED_KEYS, m_SelectedKey.c_str());
+
+		// If doing shifted key, start with Shift checkbox checked because that's most likely
+		// what the user wants
+		DlgItemCheck(m_hwnd, IDC_SHIFT, m_Shift);
+
 		return TRUE;
 
 	case WM_ACTIVATE:
@@ -188,9 +195,23 @@ int SelectKeyDialog::Key() const
 
 /****************************************************************************/
 
+bool SelectKeyDialog::Shift() const
+{
+	return m_Shift;
+}
+
+/****************************************************************************/
+
 static bool IsDlgItemChecked(HWND hDlg, int nIDDlgItem)
 {
 	return SendDlgItemMessage(hDlg, nIDDlgItem, BM_GETCHECK, 0, 0) == BST_CHECKED;
+}
+
+/****************************************************************************/
+
+static void DlgItemCheck(HWND hDlg, int nIDDlgItem, bool checked)
+{
+	SendDlgItemMessage(hDlg, nIDDlgItem, BM_SETCHECK, checked ? BST_CHECKED : BST_UNCHECKED, 0);
 }
 
 /****************************************************************************/

--- a/Src/SelectKeyDialog.cpp
+++ b/Src/SelectKeyDialog.cpp
@@ -107,10 +107,12 @@ INT_PTR SelectKeyDialog::DlgProc(
 		if (LOWORD(wParam) == WA_INACTIVE)
 		{
 			hCurrentDialog = nullptr;
+			mainWin->m_JoystickTarget = nullptr;
 		}
 		else
 		{
 			hCurrentDialog = m_hwnd;
+			mainWin->m_JoystickTarget = m_hwnd;
 			hCurrentAccelTable = nullptr;
 		}
 		break;
@@ -196,6 +198,51 @@ static bool IsDlgItemChecked(HWND hDlg, int nIDDlgItem)
 LPCSTR SelectKeyDialog::KeyName(int Key)
 {
 	static CHAR Character[2]; // Used to return single characters.
+
+	if (Key >= 256 && Key < BEEB_VKEY_COUNT)
+	{
+		static CHAR Name[16]; // Buffer for joystick button or axis name
+		Key -= 256;
+		if (Key > BEEB_VKEY_JOY2_AXES - BEEB_VKEY_JOY1_AXES)
+		{
+			strcpy(Name, "Joy2");
+			Key -= BEEB_VKEY_JOY2_AXES - BEEB_VKEY_JOY1_AXES;
+		}
+		else
+		{
+			strcpy(Name, "Joy1");
+		}
+
+		if (Key < BEEB_VKEY_JOY1_BTN1 - BEEB_VKEY_JOY1_AXES)
+		{
+			if (Key == BEEB_JOY_AX_UP)
+			{
+				strcat(Name, "Up");
+			}
+			else if (Key == BEEB_JOY_AX_DOWN)
+			{
+				strcat(Name, "Down");
+			}
+			else if (Key == BEEB_JOY_AX_LEFT)
+			{
+				strcat(Name, "Left");
+			}
+			else if (Key == BEEB_JOY_AX_RIGHT)
+			{
+				strcat(Name, "Right");
+			}
+			else
+			{
+				sprintf(Name + strlen(Name), "Axis%d", (Key / 2) + 1);
+				strcat(Name, (Key & 1) ? "+" : "-");
+			}
+		}
+		else
+		{
+			sprintf(Name + strlen(Name), "Btn%d", Key - (BEEB_VKEY_JOY1_BTN1 - BEEB_VKEY_JOY1_AXES) + 1);
+		}
+		return Name;
+	}
 
 	switch (Key)
 	{

--- a/Src/SelectKeyDialog.cpp
+++ b/Src/SelectKeyDialog.cpp
@@ -104,7 +104,12 @@ INT_PTR SelectKeyDialog::DlgProc(
 
 		SetDlgItemText(m_hwnd, IDC_ASSIGNED_KEYS, m_SelectedKey.c_str());
 
-		// If doing shifted key, start with Shift checkbox checked because that's most likely
+		// If the selected keys is empty (as opposed to "Not assigned"), we are currently unassigning.
+		// Hide the "Assigned to:" label
+		if (m_SelectedKey.empty())
+			SetDlgItemText(m_hwnd, IDC_ASSIGNED_KEYS_LBL, "");
+
+		// If doing shifted key, start with the Shift checkbox checked because that's most likely
 		// what the user wants
 		DlgItemCheck(m_hwnd, IDC_SHIFT, m_Shift);
 
@@ -270,6 +275,7 @@ LPCSTR SelectKeyDialog::KeyName(int Key)
 	case   8: return "Backspace";
 	case   9: return "Tab";
 	case  13: return "Enter";
+	case  16: return "Shift";
 	case  17: return "Ctrl";
 	case  18: return "Alt";
 	case  19: return "Break";

--- a/Src/SelectKeyDialog.h
+++ b/Src/SelectKeyDialog.h
@@ -30,7 +30,8 @@ class SelectKeyDialog
 			HINSTANCE hInstance,
 			HWND hwndParent,
 			const std::string& Title,
-			const std::string& SelectedKey
+			const std::string& SelectedKey,
+			bool doingShifted = false
 		);
 
 		bool Open();
@@ -39,6 +40,7 @@ class SelectKeyDialog
 		bool HandleMessage(const MSG& msg);
 
 		int Key() const;
+		bool Shift() const;
 
 		static LPCSTR KeyName(int Key);
 

--- a/Src/beebemrc.h
+++ b/Src/beebemrc.h
@@ -97,6 +97,7 @@ Boston, MA  02110-1301, USA.
 #define IDK_BACKSLASH                   81
 #define IDK_UNDERSCORE                  82
 #define IDK_CARET                       83
+#define IDK_UNASSIGN                    84
 #define IDR_MENU                        101
 #define IDI_BEEBEM                      102
 #define IDD_USERKYBRD                   103
@@ -186,6 +187,7 @@ Boston, MA  02110-1301, USA.
 #define IDC_SHIFT                       1088
 #define IDC_DEBUGTELETEXTBRK            1089
 #define IDC_ASSIGNED_KEYS               1090
+#define IDC_ASSIGNED_KEYS_LBL           1091
 #define IDM_ABOUT                       40001
 #define IDM_DISC                        40002
 #define IDM_LOADDISC0                   40002
@@ -441,13 +443,13 @@ Boston, MA  02110-1301, USA.
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
-//
+// 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        118
 #define _APS_NEXT_COMMAND_VALUE         40298
-#define _APS_NEXT_CONTROL_VALUE         1090
+#define _APS_NEXT_CONTROL_VALUE         1092
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/Src/beebemrc.h
+++ b/Src/beebemrc.h
@@ -437,6 +437,7 @@ Boston, MA  02110-1301, USA.
 #define ID_VIEW_DD_2560X1440            40294
 #define ID_VIEW_DD_3840X2160            40295
 #define IDM_EMUPAUSED                   40296
+#define IDM_JOYSTICK_TO_KEYS            40297
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -445,7 +446,7 @@ Boston, MA  02110-1301, USA.
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        118
-#define _APS_NEXT_COMMAND_VALUE         40297
+#define _APS_NEXT_COMMAND_VALUE         40298
 #define _APS_NEXT_CONTROL_VALUE         1090
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/Src/beebwin.cpp
+++ b/Src/beebwin.cpp
@@ -1154,6 +1154,7 @@ void BeebWin::SetRomMenu(void)
 void BeebWin::InitJoystick(void)
 {
 	MMRESULT mmresult = JOYERR_NOERROR;
+	MMRESULT mmresult2;
 
 	if ((m_MenuIdSticks == IDM_JOYSTICK || m_JoystickToKeys) && !m_JoystickCaptured)
 	{
@@ -1168,10 +1169,10 @@ void BeebWin::InitJoystick(void)
 	if (m_JoystickToKeys && !m_Joystick2Captured)
 	{
 		/* Get joystick updates 10 times a second */
-		mmresult = joySetCapture(m_hWnd, JOYSTICKID2, 100, FALSE);
-		if (mmresult == JOYERR_NOERROR)
-			mmresult = joyGetDevCaps(JOYSTICKID2, &m_Joystick2Caps, sizeof(JOYCAPS));
-		if (mmresult == JOYERR_NOERROR)
+		mmresult2 = joySetCapture(m_hWnd, JOYSTICKID2, 100, FALSE);
+		if (mmresult2 == JOYERR_NOERROR)
+			mmresult2 = joyGetDevCaps(JOYSTICKID2, &m_Joystick2Caps, sizeof(JOYCAPS));
+		if (mmresult2 == JOYERR_NOERROR)
 			m_Joystick2Captured = true;
 	}
 
@@ -1285,8 +1286,8 @@ void BeebWin::TranslateOrSendKey(int vkey, bool keyUp)
 	}
 	else if (!keyUp)
 	{
-		/* Keyboard input dialog is visible - translate button down to key up and send to dialog */
-		PostMessage(m_JoystickTarget, WM_KEYUP, vkey, 0);
+		// Keyboard input dialog is visible - translate button down to key down message and send to dialog
+		PostMessage(m_JoystickTarget, WM_KEYDOWN, vkey, 0);
 	}
 }
 
@@ -1352,10 +1353,10 @@ void BeebWin::TranslateJoystick(int joyId)
 		JOYINFOEX joyInfoEx;
 		joyInfoEx.dwSize = sizeof(joyInfoEx);
 		joyInfoEx.dwFlags = JOY_RETURNALL | JOY_RETURNPOVCTS;
-		if (!joyGetPosEx(0, &joyInfoEx))
+		if (!joyGetPosEx(joyId, &joyInfoEx))
 		{
-			mainWin->TranslateJoystickMove(0, joyInfoEx);
-			mainWin->TranslateJoystickButtons(0, joyInfoEx.dwButtons);
+			mainWin->TranslateJoystickMove(joyId, joyInfoEx);
+			mainWin->TranslateJoystickButtons(joyId, joyInfoEx.dwButtons);
 		}
 	}
 }
@@ -1440,7 +1441,6 @@ LRESULT CALLBACK WndProc(HWND hWnd,     // window handle
 	int wmId, wmEvent;
 	HDC hdc;
 	int row, col;
-	JOYINFOEX joyInfoEx;
 
 	switch (message)
 	{

--- a/Src/beebwinio.cpp
+++ b/Src/beebwinio.cpp
@@ -155,6 +155,8 @@ int BeebWin::ReadDisc(int Drive, bool bCheckForPrefs)
 		if (bCheckForPrefs)
 		{
 			// Check for file specific preferences files
+			m_ExtraPrefsFile[0] = '\0';
+			m_OverrideKeyMapPath = false;
 			CheckForLocalPrefs(FileName, true);
 		}
 
@@ -540,6 +542,8 @@ void BeebWin::RestoreState()
 	if (fileDialog.Open())
 	{
 		// Check for file specific preferences files
+		m_ExtraPrefsFile[0] = '\0';
+		m_OverrideKeyMapPath = false;
 		CheckForLocalPrefs(FileName, true);
 
 		if (m_AutoSavePrefsFolders)
@@ -1090,15 +1094,19 @@ bool BeebWin::ReadKeyMap(const char *filename, KeyMap *keymap)
 		{
 			fgets(buf, 255, infile);
 
-			for (int i = 0; i < 256; ++i)
+			for (int i = 0; i < BEEB_VKEY_COUNT; ++i)
 			{
 				if (fgets(buf, 255, infile) == NULL)
 				{
-					char errstr[500];
-					sprintf(errstr, "Data missing from key map file:\n  %s\n", filename);
-					MessageBox(GETHWND, errstr, WindowTitle, MB_OK|MB_ICONERROR);
-					success = false;
-					break;
+					/* Ignore missing joystrick binding */
+					if (i < 256)
+					{
+						char errstr[500];
+						sprintf(errstr, "Data missing from key map file:\n  %s\n", filename);
+						MessageBox(GETHWND, errstr, WindowTitle, MB_OK | MB_ICONERROR);
+						success = false;
+						break;
+					}
 				}
 
 				int shift0 = 0, shift1 = 0;
@@ -1151,7 +1159,7 @@ bool BeebWin::WriteKeyMap(const char *filename, KeyMap *keymap)
 	{
 		fprintf(outfile, KEYMAP_TOKEN "\n\n");
 
-		for (int i = 0; i < 256; ++i)
+		for (int i = 0; i < BEEB_VKEY_COUNT; ++i)
 		{
 			fprintf(outfile, "%d %d %d %d %d %d\n",
 					(*keymap)[i][0].row,

--- a/Src/userkybd.cpp
+++ b/Src/userkybd.cpp
@@ -137,7 +137,7 @@ static void SelectKeyMapping(HWND hwnd, UINT ctrlID, HWND hwndCtrl)
 
 static void SetBBCKeyForVKEY(int Key, bool Shift)
 {
-	if (Key >= 0 && Key < 256)
+	if (Key >= 0 && Key < BEEB_VKEY_COUNT)
 	{
 		UserKeymap[Key][static_cast<int>(Shift)].row = BBCRow;
 		UserKeymap[Key][static_cast<int>(Shift)].col = BBCCol;
@@ -466,7 +466,7 @@ static std::string GetKeysUsed()
 	// First see if this key is defined.
 	if (BBCRow != 0 || BBCCol != 0)
 	{
-		for (int i = 1; i < 256; i++)
+		for (int i = 1; i < BEEB_VKEY_COUNT; i++)
 		{
 			for (int s = 0; s < 2; ++s)
 			{

--- a/Src/userkybd.cpp
+++ b/Src/userkybd.cpp
@@ -283,7 +283,7 @@ static INT_PTR CALLBACK UserKeyboardDlgProc(HWND   hwnd,
 			// Assign the BBC key to the PC key.
 			SetBBCKeyForVKEY(
 				selectKeyDialog->Key(),
-				doingShifted
+				selectKeyDialog->Shift()
 			);
 		}
 
@@ -300,7 +300,8 @@ static INT_PTR CALLBACK UserKeyboardDlgProc(HWND   hwnd,
 				hInst,
 				hwndUserKeyboard,
 				szSelectKeyDialogTitle[doingShifted ? 1 : 0],
-				UsedKeys
+				UsedKeys,
+				doingShifted
 			);
 
 			selectKeyDialog->Open();


### PR DESCRIPTION
- Assigning host joystick axes and buttons to BBC keyboard
- Look for disk specific keyboard mapping file (disk name + .kmap extension)
- Look for disk specific extra preferences file (disk name + .cfg extension)

Joystick assignmen is saved in keyboard mapping file, which makes the kmap file longer. Previous version of beebem will ignore extra lines, and this version will accept previous of kmap file, setting joystick actions unassigned.