### PR TITLE
Fix for Solidisk Sideways RAM

### DIFF
--- a/Src/beebmem.cpp
+++ b/Src/beebmem.cpp
@@ -675,7 +675,7 @@ void BeebWriteMem(int Address, unsigned char Value) {
 		}
 
 		if (Address < 0xc000 && Address >= 0x8000) {
-			if (RomWritable[ROMSEL]) Roms[ROMSEL][Address -0x8000] =Value;
+			if (!SWRAMBoardEnabled && RomWritable[ROMSEL]) Roms[ROMSEL][Address -0x8000] =Value;
 			else RomWriteThrough(Address, Value);
 			return;
 		}


### PR DESCRIPTION
Write to RAM bank selected by User VIA output port B even if bank selected by &FE30 is writable.

Testing:
* Start with default Model B configuration
* Enable "SW RAM Board"
* Configure banks C-F as RAM, check "Allow SW RAM Write" for those banks
* Move basic2 and dnfs to e.g. banks 8 and 9
* Run Solidisk Sideways RAM utils vol 1 (it can be downloaded from here: https://stardot.org.uk/forums/download/file.php?id=3340)
* Without the patch, the menu program crashes (older version that I have doesn't crash but only displays one bank available)
* With the patch, the menu program correctly displays "4 Sideways Ram Banks Available"

This is related to #70