### PR TITLE
Capture mouse option

### DIFF
--- a/Src/BeebEm.rc
+++ b/Src/BeebEm.rc
@@ -626,6 +626,7 @@ BEGIN
     POPUP "&AMX"
     BEGIN
         MENUITEM "&On/Off",                     IDM_AMXONOFF
+        MENUITEM "Capture Mouse",               IDM_CAPTUREMOUSE
         MENUITEM SEPARATOR
         MENUITEM "L+R for &Middle",             IDM_AMX_LRFORMIDDLE
         MENUITEM SEPARATOR

--- a/Src/beebemrc.h
+++ b/Src/beebemrc.h
@@ -433,6 +433,7 @@ Boston, MA  02110-1301, USA.
 #define ID_VIEW_DD_2560X1440            40294
 #define ID_VIEW_DD_3840X2160            40295
 #define IDM_EMUPAUSED                   40296
+#define IDM_CAPTUREMOUSE                40318
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -441,7 +442,7 @@ Boston, MA  02110-1301, USA.
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        118
-#define _APS_NEXT_COMMAND_VALUE         40297
+#define _APS_NEXT_COMMAND_VALUE         40319
 #define _APS_NEXT_CONTROL_VALUE         1090
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/Src/beebwin.cpp
+++ b/Src/beebwin.cpp
@@ -4121,10 +4121,6 @@ void BeebWin::CaptureMouse()
 	if (!RegisterRawInputDevices(Rid, 1, sizeof(Rid[0])))
 		return;
 
-	// Display info on title bar
-	std::string tempTitle = WindowTitle + std::string(" (Press Ctrl+Alt to release mouse)");
-	SetWindowText(m_hWnd, tempTitle.c_str());
-
 	// Capture mouse
 	m_MouseCaptured = true;
 	SetCapture(m_hWnd);
@@ -4142,6 +4138,9 @@ void BeebWin::CaptureMouse()
 	GetClientRect(m_hWnd, &clientRect);
 	MapWindowPoints(m_hWnd, nullptr, reinterpret_cast<LPPOINT>(&clientRect), 2);
 	ClipCursor(&clientRect);
+
+	// Display info on title bar
+	UpdateWindowTitle();
 }
 
 void BeebWin::ReleaseMouse()
@@ -4160,9 +4159,6 @@ void BeebWin::ReleaseMouse()
 
 	ClipCursor(nullptr);
 
-	// Restore original window title
-	SetWindowText(m_hWnd, WindowTitle);
-
 	// Show cursor in the centre of the window
 	POINT centre{ m_XWinSize / 2, m_YWinSize / 2 };
 	ClientToScreen(m_hWnd, &centre);
@@ -4173,6 +4169,9 @@ void BeebWin::ReleaseMouse()
 	ReleaseCapture();
 
 	m_MouseCaptured = false;
+
+	// Restore original window title
+	UpdateWindowTitle();
 }
 
 void BeebWin::OpenUserKeyboardDialog()

--- a/Src/beebwin.cpp
+++ b/Src/beebwin.cpp
@@ -1656,11 +1656,15 @@ LRESULT CALLBACK WndProc(HWND hWnd,     // window handle
 			if (mainWin->m_MouseCaptured)
 			{
 				UINT dwSize = sizeof(RAWINPUT);
-				static BYTE lpb[sizeof(RAWINPUT)];
+				BYTE Buffer[sizeof(RAWINPUT)];
 
-				GetRawInputData((HRAWINPUT)lParam, RID_INPUT, lpb, &dwSize, sizeof(RAWINPUTHEADER));
+				GetRawInputData((HRAWINPUT)lParam,
+				                RID_INPUT,
+				                Buffer,
+				                &dwSize,
+				                sizeof(RAWINPUTHEADER));
 
-				RAWINPUT* raw = (RAWINPUT*)lpb;
+				RAWINPUT* raw = reinterpret_cast<RAWINPUT*>(Buffer);
 
 				if (raw->header.dwType != RIM_TYPEMOUSE)
 					break;
@@ -1669,6 +1673,7 @@ LRESULT CALLBACK WndProc(HWND hWnd,     // window handle
 				int yDelta = raw->data.mouse.lLastY;
 
 				mainWin->m_RelMousePos.x += xDelta;
+
 				if (mainWin->m_RelMousePos.x < 0)
 				{
 					mainWin->m_RelMousePos.x = 0;
@@ -1679,6 +1684,7 @@ LRESULT CALLBACK WndProc(HWND hWnd,     // window handle
 				}
 
 				mainWin->m_RelMousePos.y += yDelta;
+
 				if (mainWin->m_RelMousePos.y < 0)
 				{
 					mainWin->m_RelMousePos.y = 0;
@@ -1688,7 +1694,9 @@ LRESULT CALLBACK WndProc(HWND hWnd,     // window handle
 					mainWin->m_RelMousePos.y = mainWin->m_YWinSize;
 				}
 
-				mainWin->ScaleMousestick(mainWin->m_RelMousePos.x, mainWin->m_RelMousePos.y);
+				mainWin->ScaleMousestick(mainWin->m_RelMousePos.x,
+				                         mainWin->m_RelMousePos.y);
+
 				mainWin->ChangeAMXPosition(xDelta, yDelta);
 			}
 			break;
@@ -4094,10 +4102,11 @@ bool BeebWin::IsPaused()
 }
 
 #ifndef HID_USAGE_PAGE_GENERIC
-#define HID_USAGE_PAGE_GENERIC         ((USHORT) 0x01)
+#define HID_USAGE_PAGE_GENERIC ((USHORT)0x01)
 #endif
+
 #ifndef HID_USAGE_GENERIC_MOUSE
-#define HID_USAGE_GENERIC_MOUSE        ((USHORT) 0x02)
+#define HID_USAGE_GENERIC_MOUSE ((USHORT)0x02)
 #endif
 
 void BeebWin::CaptureMouse()

--- a/Src/beebwin.h
+++ b/Src/beebwin.h
@@ -201,7 +201,9 @@ public:
 	int StartOfFrame(void);
 	bool UpdateTiming();
 	void AdjustSpeed(bool up);
-	void DisplayTiming(void);
+	bool ShouldDisplayTiming() const;
+	void DisplayTiming();
+	void UpdateWindowTitle();
 	bool IsWindowMinimized() const;
 	void DisplayClientAreaText(HDC hdc);
 	void DisplayFDCBoardInfo(HDC hDC, int x, int y);
@@ -351,7 +353,7 @@ public:
 	HDC 		m_hDCBitmap;
 	HGDIOBJ 	m_hBitmap;
 	bmiData 	m_bmi;
-	char		m_szTitle[100];
+	char m_szTitle[256];
 
 	int		m_ScreenRefreshCount;
 	double		m_RelativeSpeed;

--- a/Src/beebwin.h
+++ b/Src/beebwin.h
@@ -309,9 +309,6 @@ public:
 	bool		m_HideCursor;
 	bool		m_CaptureMouse;
 	bool		m_MouseCaptured;
-	bool		m_RawInputRegistered;
-	POINT		m_PrevMousePos;
-	POINT		m_MousePos;
 	POINT		m_RelMousePos;
 	bool		m_FreezeWhenInactive;
 	int		m_MenuIdKeyMapping;

--- a/Src/beebwin.h
+++ b/Src/beebwin.h
@@ -309,6 +309,7 @@ public:
 	bool		m_HideCursor;
 	bool		m_CaptureMouse;
 	bool		m_MouseCaptured;
+	bool		m_RawInputRegistered;
 	POINT		m_PrevMousePos;
 	POINT		m_MousePos;
 	POINT		m_RelMousePos;

--- a/Src/beebwin.h
+++ b/Src/beebwin.h
@@ -210,6 +210,9 @@ public:
 	void ScaleMousestick(unsigned int x, unsigned int y);
 	void HandleCommand(int MenuId);
 	void SetAMXPosition(unsigned int x, unsigned int y);
+	void ChangeAMXPosition(int deltaX, int deltaY);
+	void CaptureMouse();
+	void ReleaseMouse();
 	void Activate(bool active);
 	void Focus(bool gotit);
 	void WinSizeChange(int size, int width, int height);
@@ -304,6 +307,11 @@ public:
 	JOYCAPS		m_JoystickCaps;
 	int		m_MenuIdSticks;
 	bool		m_HideCursor;
+	bool		m_CaptureMouse;
+	bool		m_MouseCaptured;
+	POINT		m_PrevMousePos;
+	POINT		m_MousePos;
+	POINT		m_RelMousePos;
 	bool		m_FreezeWhenInactive;
 	int		m_MenuIdKeyMapping;
 	bool		m_KeyMapAS;

--- a/Src/beebwindx.cpp
+++ b/Src/beebwindx.cpp
@@ -834,12 +834,51 @@ void BeebWin::DisplayFDCBoardInfo(HDC hDC, int x, int y)
 }
 
 /****************************************************************************/
-void BeebWin::DisplayTiming(void)
+
+static const char* pszReleaseCaptureMessage = "(Press Ctrl+Alt to release mouse)";
+
+bool BeebWin::ShouldDisplayTiming() const
 {
-	if (m_ShowSpeedAndFPS && (m_DisplayRenderer == IDM_DISPGDI || !m_isFullScreen))
+	return m_ShowSpeedAndFPS && (m_DisplayRenderer == IDM_DISPGDI || !m_isFullScreen);
+}
+
+void BeebWin::DisplayTiming()
+{
+	if (ShouldDisplayTiming())
 	{
-		sprintf(m_szTitle, "%s  Speed: %2.2f  fps: %2d",
-				WindowTitle, m_RelativeSpeed, (int)m_FramesPerSecond);
+		if (m_MouseCaptured)
+		{
+			sprintf(m_szTitle, "%s  Speed: %2.2f  fps: %2d  %s",
+			        WindowTitle, m_RelativeSpeed, (int)m_FramesPerSecond, pszReleaseCaptureMessage);
+		}
+		else
+		{
+			sprintf(m_szTitle, "%s  Speed: %2.2f  fps: %2d",
+			        WindowTitle, m_RelativeSpeed, (int)m_FramesPerSecond);
+		}
+
+		SetWindowText(m_hWnd, m_szTitle);
+	}
+}
+
+void BeebWin::UpdateWindowTitle()
+{
+	if (ShouldDisplayTiming())
+	{
+		DisplayTiming();
+	}
+	else
+	{
+		if (m_MouseCaptured)
+		{
+			sprintf(m_szTitle, "%s  %s",
+			        WindowTitle, pszReleaseCaptureMessage);
+		}
+		else
+		{
+			strcpy(m_szTitle, WindowTitle);
+		}
+
 		SetWindowText(m_hWnd, m_szTitle);
 	}
 }

--- a/Src/beebwinprefs.cpp
+++ b/Src/beebwinprefs.cpp
@@ -64,6 +64,7 @@ static const char *CFG_OPTIONS_KEY_MAPPING = "KeyMapping";
 static const char *CFG_OPTIONS_USER_KEY_MAP_FILE = "UserKeyMapFile";
 static const char *CFG_OPTIONS_FREEZEINACTIVE = "FreezeWhenInactive";
 static const char *CFG_OPTIONS_HIDE_CURSOR = "HideCursor";
+static const char* CFG_OPTIONS_CAPTURE_MOUSE = "CaptureMouse";
 static const char *CFG_SPEED_TIMING = "Timing";
 static const char *CFG_AMX_ENABLED = "AMXMouseEnabled";
 static const char *CFG_AMX_LRFORMIDDLE = "AMXMouseLRForMiddle";
@@ -251,6 +252,9 @@ void BeebWin::LoadPreferences()
 
 	if (!m_Preferences.GetBoolValue(CFG_OPTIONS_HIDE_CURSOR, m_HideCursor))
 		m_HideCursor = false;
+
+	if (!m_Preferences.GetBoolValue(CFG_OPTIONS_CAPTURE_MOUSE, m_CaptureMouse))
+		m_CaptureMouse = false;
 
 	if (m_Preferences.GetDWORDValue(CFG_OPTIONS_KEY_MAPPING,dword))
 		m_MenuIdKeyMapping = dword;
@@ -630,6 +634,7 @@ void BeebWin::SavePreferences(bool saveAll)
 		m_Preferences.SetDWORDValue( CFG_OPTIONS_STICKS, m_MenuIdSticks);
 		m_Preferences.SetBoolValue(CFG_OPTIONS_FREEZEINACTIVE, m_FreezeWhenInactive);
 		m_Preferences.SetBoolValue(CFG_OPTIONS_HIDE_CURSOR, m_HideCursor);
+		m_Preferences.SetBoolValue(CFG_OPTIONS_CAPTURE_MOUSE, m_CaptureMouse);
 		m_Preferences.SetDWORDValue( CFG_OPTIONS_KEY_MAPPING, m_MenuIdKeyMapping);
 		m_Preferences.SetBoolValue("KeyMapAS", m_KeyMapAS);
 		flag = m_KeyMapFunc;

--- a/Src/uservia.cpp
+++ b/Src/uservia.cpp
@@ -501,14 +501,15 @@ void AMXMouseMovement()
 {
 	int xdir = 0, ydir = 0;
 	int xpulse, ypulse;
+	int deltaX = 0, deltaY =0;
 
 	ClearTrigger(AMXTrigger);
 
 	/* Check if there is a outstanding interrupt */
 	if (AMXMouseEnabled && (UserVIAState.ifr & 0x18) == 0)
 	{
-		int deltaX = AMXDeltaX == 0 ? AMXTargetX - AMXCurrentX : AMXDeltaX;
-		int deltaY = AMXDeltaY == 0 ? AMXTargetY - AMXCurrentY : AMXDeltaY;
+		deltaX = AMXDeltaX == 0 ? AMXTargetX - AMXCurrentX : AMXDeltaX;
+		deltaY = AMXDeltaY == 0 ? AMXTargetY - AMXCurrentY : AMXDeltaY;
 
 		if (deltaX != 0 || deltaY != 0)
 		{
@@ -573,7 +574,15 @@ void AMXMouseMovement()
 
 			UpdateIFRTopBit();
 		}
+#if 0
+		static int prevCycles = 0;
+		char buf[256];
+		snprintf(buf, 256, "dT=%d dX=%d dY=%d x=%d y=%d\n", TotalCycles - prevCycles, deltaX, deltaY, xdir, ydir);
+		OutputDebugString(buf);
+		prevCycles = TotalCycles;
+#endif
 	}
+
 }
 
 /*-------------------------------------------------------------------------*/

--- a/Src/uservia.cpp
+++ b/Src/uservia.cpp
@@ -499,22 +499,20 @@ static void UpdateSRState(bool SRrw)
 /*-------------------------------------------------------------------------*/
 void AMXMouseMovement()
 {
-	int xdir = 0, ydir = 0;
-	int xpulse, ypulse;
-	int deltaX = 0, deltaY =0;
-
 	ClearTrigger(AMXTrigger);
 
-	/* Check if there is a outstanding interrupt */
+	// Check if there is an outstanding interrupt.
 	if (AMXMouseEnabled && (UserVIAState.ifr & 0x18) == 0)
 	{
-		deltaX = AMXDeltaX == 0 ? AMXTargetX - AMXCurrentX : AMXDeltaX;
-		deltaY = AMXDeltaY == 0 ? AMXTargetY - AMXCurrentY : AMXDeltaY;
+		int deltaX = AMXDeltaX == 0 ? AMXTargetX - AMXCurrentX : AMXDeltaX;
+		int deltaY = AMXDeltaY == 0 ? AMXTargetY - AMXCurrentY : AMXDeltaY;
 
 		if (deltaX != 0 || deltaY != 0)
 		{
-			xdir = sgn(deltaX);
-			ydir = sgn(deltaY);
+			int xdir = sgn(deltaX);
+			int ydir = sgn(deltaY);
+
+			int xpulse, ypulse;
 
 			if (TubeType == Tube::Master512CoPro)
 			{
@@ -534,7 +532,7 @@ void AMXMouseMovement()
 				else
 					UserVIAState.irb |= xpulse;
 
-				if (!(UserVIAState.pcr & 0x10))            // Interrupt on falling CB1 edge
+				if (!(UserVIAState.pcr & 0x10)) // Interrupt on falling CB1 edge
 				{
 					// Warp time to the falling edge, invert the input
 					UserVIAState.irb ^= xpulse;
@@ -542,7 +540,6 @@ void AMXMouseMovement()
 
 				// Trigger the interrupt
 				UserVIAState.ifr |= 0x10;
-
 			}
 
 			if (ydir)
@@ -552,7 +549,7 @@ void AMXMouseMovement()
 				else
 					UserVIAState.irb &= ~ypulse;
 
-				if (!(UserVIAState.pcr & 0x40))	           // Interrupt on falling CB2 edge
+				if (!(UserVIAState.pcr & 0x40)) // Interrupt on falling CB2 edge
 				{
 					// Warp time to the falling edge, invert the input
 					UserVIAState.irb ^= ypulse;
@@ -574,15 +571,7 @@ void AMXMouseMovement()
 
 			UpdateIFRTopBit();
 		}
-#if 0
-		static int prevCycles = 0;
-		char buf[256];
-		snprintf(buf, 256, "dT=%d dX=%d dY=%d x=%d y=%d\n", TotalCycles - prevCycles, deltaX, deltaY, xdir, ydir);
-		OutputDebugString(buf);
-		prevCycles = TotalCycles;
-#endif
 	}
-
 }
 
 /*-------------------------------------------------------------------------*/

--- a/Src/uservia.cpp
+++ b/Src/uservia.cpp
@@ -247,6 +247,8 @@ void UserVIAWrite(int Address, int Value) {
 unsigned char UserVIARead(int Address)
 {
   unsigned char tmp = 0xff;
+  // Local copy for processing middle button
+  int amxButtons = AMXButtons;
   /* cerr << "UserVIARead: Address=0x" << hex << Address << dec << " at " << TotalCycles << "\n";
   DumpRegs(); */
 
@@ -265,28 +267,26 @@ unsigned char UserVIARead(int Address)
 
 	  if (AMXMouseEnabled) {
         if (AMXLRForMiddle) {
-          if ((AMXButtons & AMX_LEFT_BUTTON) && (AMXButtons & AMX_RIGHT_BUTTON))
-            AMXButtons = AMX_MIDDLE_BUTTON;
-          else
-            AMXButtons &= ~AMX_MIDDLE_BUTTON;
+          if ((amxButtons & AMX_LEFT_BUTTON) && (amxButtons & AMX_RIGHT_BUTTON))
+            amxButtons = AMX_MIDDLE_BUTTON;
         }
 
         if (TubeType == Tube::Master512CoPro)
         {
             tmp &= 0xf8;
-            tmp |= (AMXButtons ^ 7);
+            tmp |= (amxButtons ^ 7);
         }
         else
         {
             tmp &= 0x1f;
-            tmp |= (AMXButtons ^ 7) << 5;
+            tmp |= (amxButtons ^ 7) << 5;
             UserVIAState.ifr&=0xe7;
         }
         
         UpdateIFRTopBit();
 
         /* Set up another interrupt if not at target */
-        if ( (AMXTargetX != AMXCurrentX) || (AMXTargetY != AMXCurrentY) || AMXDeltaX || AMXDeltaY) {
+        if ((AMXTargetX != AMXCurrentX) || (AMXTargetY != AMXCurrentY) || AMXDeltaX || AMXDeltaY) {
           SetTrigger(AMX_TRIGGER, AMXTrigger);
         }
         else {

--- a/Src/uservia.h
+++ b/Src/uservia.h
@@ -57,6 +57,8 @@ extern int AMXTargetX;
 extern int AMXTargetY;
 extern int AMXCurrentX;
 extern int AMXCurrentY;
+extern int AMXDeltaX;
+extern int AMXDeltaY;
 
 /* Button states */
 #define AMX_LEFT_BUTTON 1

--- a/Src/uservia.h
+++ b/Src/uservia.h
@@ -46,7 +46,7 @@ extern bool AMXMouseEnabled;
 extern bool AMXLRForMiddle;
 
 /* Number of cycles between each mouse interrupt */
-#define AMX_TRIGGER 1000
+#define AMX_TRIGGER 250
 extern int AMXTrigger;
 
 /* Checks if a movement interrupt should be generated */


### PR DESCRIPTION
Capture mouse option

This PR adds new menu item "Capture Mouse" to AMX menu. This functionality is only active when AMX mouse is enabled. Its purpose is to prevent mouse cursor from leaving the beebem window or hitting edge of the screen, which limits AMX mouse movements.

To capture the mouse, enable the "Capture Mouse" menu item and click in the window area. The cursor will become invisible and confined near the centre of the beebem window (or the screen area in full screen mode).

To release the mouse, press CTRL+ALT (this information is displayed on the window title when the mouse is captured).

Mouse is also automatically released when beebem switches between full screen and windowed mode and when beebem window becomes inactive (e.g. using ALT+TAB).

This possibly makes "Hide Cursor" option redundant, but I didn't remove that option - it still might be useful in some cases.
