### PR TITLE
Fix for Mac compatibility using same source code for both versions 

### DIFF
--- a/Src/econet.cpp
+++ b/Src/econet.cpp
@@ -107,7 +107,7 @@ struct AUNHeader
 	unsigned char port;   // dest port
 	unsigned char cb;     // flag
 	unsigned char pad;    // retrans
-	unsigned long handle; // 4 byte sequence little-endian.
+	uint32_t handle;      // 4 byte sequence little-endian.
 };
 
 // #define EC_PORT_FS 0x99


### PR DESCRIPTION
for handle variable which is part of the AUNHeader Struct.  On the Mac a long is 64 bits long not 32 so was extending the length of the struct by 4 bytes meaning PiEconetBridge was getting malformed messages.