### PR TITLE
Remove D3DX9 dependency and fix WIndows 10 SDK build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ If you want to compile BeebEm yourself then you will need Microsoft Visual Studi
 | `InnoSetup\Installer.vcxproj`        | Inno Setup installer project file |
 | `ZipFile\ZipFile.vcxproj`            | Distribution zip project file     |
 
-These project files are set up to target Windows XP, which we use to create release binaries. This requires the following optional Visual Studio 2019 components to be installed:
+Please note that these project files are set up to target Windows XP, which we use to create release binaries. This requires the following optional Visual Studio 2019 components to be installed:
 
 * MSVC v140 - VS 2015 C++ build tools (v14.00)
 * C++ Windows XP Support for VS 2017 (v141) tools [Deprecated]
 
-You also will need to download and install the [Microsoft DirectX 9.0 SDK (June 2010)](https://www.microsoft.com/en-us/download/details.aspx?id=6812).
+If you're building on Windows 10, and don't want to install anything else, see the section below for people only need Windows 10 compatibility.
+
+Otherwise: you also will need to download and install the [Microsoft DirectX 9.0 SDK (June 2010)](https://www.microsoft.com/en-us/download/details.aspx?id=6812).
 
 To build the installer from within Visual Studio, you'll need to download and install [Inno Setup 5.6.1](https://files.jrsoftware.org/is/5/).
 
@@ -66,6 +68,20 @@ This opens the BeebEm.user properties. Select **User Macros** from the list in t
 
 The "Set this macro as an environment variable in the build environment"
 option does not need to be ticked.
+
+### Instructions for people who only need Windows 10 compatibility
+
+If you don't mind targeting Windows 10, you may attempt the following unsupported steps. The advantage of doing this is that you don't need to install anything apart from Visual Studio 2019; the disadvantage is that the EXE will only support Windows 10, and the installer and distribution aren't supported.
+
+Firstly, ensure `C++ MFC for latest v142 build tools (x86 & x64)` is installed.
+
+1. Allow Visual Studio to retarget projects to v141_xp
+2. Get properties for the BeebEm project, and select `All Configurations` and `All Platforms`
+3. In `General`, set `Platform Toolset` to `Visual Studio 2019 (v142)`, and click OK
+4. Get properties for the BeebEm project, and select `All Configurations` and `All Platforms`
+5. In `General`, set `Windows SDK Version` to `10.0 (latest installed version)`, and click OK
+
+Now build.
 
 ### Other Operating Systems
 

--- a/Src/BeebWin.h
+++ b/Src/BeebWin.h
@@ -36,7 +36,7 @@ Boston, MA  02110-1301, USA.
 #include <vector>
 
 #include <windows.h>
-#include <d3dx9.h>
+#include <d3d9.h>
 #include <ddraw.h>
 #include <sapi.h>
 
@@ -114,9 +114,9 @@ struct TextToSpeechVoice
 // A structure for our custom vertex type. We added texture coordinates
 struct CUSTOMVERTEX
 {
-	D3DXVECTOR3 position; // The position
-	D3DCOLOR	color;	  // The color
-	FLOAT		tu, tv;	  // The texture coordinates
+	D3DVECTOR	position;	// The position
+	D3DCOLOR	color;		// The colour
+	FLOAT		tu, tv;		// The texture coordinates
 };
 
 // Our custom FVF, which describes our custom vertex structure
@@ -532,7 +532,7 @@ public:
 	LPDIRECT3DDEVICE9 m_pd3dDevice;
 	LPDIRECT3DVERTEXBUFFER9 m_pVB;
 	LPDIRECT3DTEXTURE9 m_pTexture;
-	D3DXMATRIX m_TextureMatrix;
+	D3DMATRIX m_TextureMatrix;
 
 	// Audio
 	UINT m_MenuIDSampleRate;

--- a/Src/BeebWinDx.cpp
+++ b/Src/BeebWinDx.cpp
@@ -40,6 +40,32 @@ typedef HRESULT (WINAPI* LPDIRECTDRAWCREATE)(GUID FAR *lpGUID, LPDIRECTDRAW FAR 
 
 /****************************************************************************/
 
+static void D3DMatrixIdentity(D3DMATRIX *pMatrix)
+{
+	pMatrix->_11 = 1.f;
+	pMatrix->_12 = 0.f; 
+	pMatrix->_13 = 0.f; 
+	pMatrix->_14 = 0.f;
+
+	pMatrix->_21 = 0.f; 
+	pMatrix->_22 = 1.f;
+	pMatrix->_23 = 0.f;
+	pMatrix->_24 = 0.f;
+
+	pMatrix->_31 = 0.f;
+	pMatrix->_32 = 0.f;
+	pMatrix->_33 = 1.f; 
+	pMatrix->_34 = 0.f;
+
+	pMatrix->_41 = 0.f;
+	pMatrix->_42 = 0.f;
+	pMatrix->_43 = 0.f; 
+	pMatrix->_44 = 1.f;
+
+}
+
+/****************************************************************************/
+
 void BeebWin::InitDX()
 {
 	HRESULT hr = E_FAIL;
@@ -371,8 +397,8 @@ HRESULT BeebWin::InitD3DDevice()
 	m_pVB = nullptr;
 	m_pTexture = nullptr;
 
-	D3DXMATRIX Ortho2D;
-	D3DXMATRIX Ident;
+	D3DMATRIX Ortho2D;
+	D3DMATRIX Ident;
 
 	// Create the D3D object on first use.
 	if (m_pD3D == nullptr)
@@ -503,23 +529,23 @@ HRESULT BeebWin::InitD3DDevice()
 		goto Fail;
 	}
 
-	pVertices[0].position = D3DXVECTOR3(0.0f, -511.0f, 0.0f);
-	pVertices[0].color    = 0x00ffffff;
+	pVertices[0].position = {0.0f, -511.0f, 0.0f};
+	pVertices[0].color    = D3DCOLOR_RGBA(255, 255, 255, 0);
 	pVertices[0].tu       = 0.0f;
 	pVertices[0].tv       = 1.0f;
 
-	pVertices[1].position = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	pVertices[1].color    = 0x00ffffff;
+	pVertices[1].position = {0.0f, 0.0f, 0.0f};
+	pVertices[1].color    = D3DCOLOR_RGBA(255, 255, 255, 0);
 	pVertices[1].tu       = 0.0f;
 	pVertices[1].tv       = 0.0f;
 
-	pVertices[2].position = D3DXVECTOR3(799.0f, -511.0f, 0.0f);
-	pVertices[2].color    = 0x00ffffff;
+	pVertices[2].position = {799.0f, -511.0f, 0.0f};
+	pVertices[2].color    = D3DCOLOR_RGBA(255, 255, 255, 0);
 	pVertices[2].tu       = 1.0f;
 	pVertices[2].tv       = 1.0f;
 
-	pVertices[3].position = D3DXVECTOR3(799.0f, 0.0f, 0.0f);
-	pVertices[3].color    = 0x00ffffff;
+	pVertices[3].position = {799.0f, 0.0f, 0.0f};
+	pVertices[3].color    = D3DCOLOR_RGBA(255, 255, 255, 0);
 	pVertices[3].tu       = 1.0f;
 	pVertices[3].tv       = 0.0f;
 
@@ -527,7 +553,7 @@ HRESULT BeebWin::InitD3DDevice()
 
 	// Set up matrices
 	//D3DXMatrixOrthoOffCenterLH(&Ortho2D, 0.0f, 800.0f, -512.0f, 0.0f, 0.0f, 1.0f);
-	D3DXMatrixIdentity(&Ortho2D);
+	D3DMatrixIdentity(&Ortho2D);
 	// const float l = 0.0f;
 	const float r = 800.0f;
 	const float b = -512.0f;
@@ -543,12 +569,12 @@ HRESULT BeebWin::InitD3DDevice()
 
 	m_pd3dDevice->SetTransform(D3DTS_PROJECTION, &Ortho2D);
 
-	D3DXMatrixIdentity(&Ident);
+	D3DMatrixIdentity(&Ident);
 	m_pd3dDevice->SetTransform(D3DTS_VIEW, &Ident);
 	m_pd3dDevice->SetTransform(D3DTS_WORLD, &Ident);
 
 	// Identity matrix will fill window with our texture
-	D3DXMatrixIdentity(&m_TextureMatrix);
+	D3DMatrixIdentity(&m_TextureMatrix);
 
 	hResult = m_pd3dDevice->CreateTexture(800,
 	                                      512,
@@ -827,7 +853,7 @@ void BeebWin::updateLines(HDC hDC, int StartY, int NLines)
 					int height = TeletextEnabled ? TeletextLines : NLines;
 					// D3DXMatrixScaling(&m_TextureMatrix,
 					//                   800.0f / (float)width, 512.0f / (float)height, 1.0f);
-					D3DXMatrixIdentity(&m_TextureMatrix);
+					D3DMatrixIdentity(&m_TextureMatrix);
 					m_TextureMatrix._11 = 800.0f/(float)width;
 					m_TextureMatrix._22 = 512.0f/(float)height;
 

--- a/Src/BeebWinSpeech.cpp
+++ b/Src/BeebWinSpeech.cpp
@@ -22,8 +22,13 @@ Boston, MA  02110-1301, USA.
 
 #include <windows.h>
 
+// If building for Windows 10, you get a C4996 warning from sphelper.h. But it's
+// an error! Even though warnings are not set to be errors.
+#pragma warning(push)
+#pragma warning(default : 4996)
 #define STRSAFE_NO_DEPRECATE
 #include <sphelper.h>
+#pragma warning(pop)
 
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
I didn't want to install the D3D9 SDK, so I fixed up the code to let it build with the standard SDK you get with Visual Studio 2019 when installed on Windows 10. This doesn't include any changes to the vcxproj files, so hopefully it hasn't broken XP compatibility.

There's a few tweaks to the C++ code so that it uses only functionality from D3D9 and not D3DX9.

And there's one change to BeebWinSpeech.cpp to fix a warning that gets mysteriously promoted to error, that I couldn't figure out any better way to get rid of.

--Tom