### PR TITLE
Don't pull up read data bits when teletext adapter is unpowered

### DIFF
--- a/Src/Teletext.cpp
+++ b/Src/Teletext.cpp
@@ -320,7 +320,7 @@ void TeletextWrite(int Address, int Value)
 unsigned char TeletextRead(int Address)
 {
     if (!TeletextAdapterEnabled)
-        return 0xff;
+        return 0x00;
 
     unsigned char data = 0x00;
 


### PR DESCRIPTION
TFS ROM always detects adapter as powered regardless of enabled setting