### PR TITLE
Make it easier to use BeebEm with networks over a Pi Econet Bridge

### DIFF
--- a/UserData/Econet.cfg
+++ b/UserData/Econet.cfg
@@ -105,6 +105,13 @@ FOURWAYTIMEOUT 500000  # default 500000. works best when same as or less than fl
 # (See Local Area connection>Properties>General>Internet Protocol>Properties>
 # Advanced>Add to add more IP addresses to a Windows PC. ifconfig alias on linux/unix)
 #
+# Change from V4.19 - Networks can be defined with a wildcard station number (*) and a
+# base port from which unknown host ports will be automatically calculated using the 
+# formula base_port + (network * 256) + station. This is equivalent to the behaviour of
+# PORT SEQ in Pi Econet Bridge, allowing a bridged network to be EXPOSEd there and defined
+# in BeebEm with a single line each.
+# Wildcard entries will be used to add unknown stations automatically, if AUNSTRICT is off.
+#
 # Example network configuration.
 # Fileserver (station ID 254) and 4 stations on the local PC:
 # 0 254 127.0.0.1 32768
@@ -124,3 +131,7 @@ FOURWAYTIMEOUT 500000  # default 500000. works best when same as or less than fl
 # Example of stations on another PC:
 # 0 10 192.168.0.10 32768
 # 0 11 192.168.0.11 32768
+
+# Example of bridged networks EXPOSED on a Pi Econet Bridge:
+# 2 * 192.168.0.20 10000
+# 3 * 192.168.0.20 10000


### PR DESCRIPTION
Implements a wildcard option to enable a whole network to be defined in one line using automatic port number calculation, rather than having to specify each host individually in econet.cfg.