### PR TITLE
Better implementation of de-tuned teletext channels

### DIFF
--- a/Src/Teletext.cpp
+++ b/Src/Teletext.cpp
@@ -550,9 +550,9 @@ void TeletextAdapterUpdate()
                                 memcpy(&(row[i][1]), TeletextSocketBuff[TeletextChannel] + j * 42, 42);
                             }
                         }
+                        rowPtr = 0x00;
+                        colPtr = 0x00;
                     }
-                    rowPtr = 0x00;
-                    colPtr = 0x00;
                 }
 
                 TeletextCurrentField ^= 1; // toggle field
@@ -582,12 +582,9 @@ void TeletextAdapterUpdate()
                                 memcpy(&(row[i][1]), buff + i * 43, 42);
                             }
                         }
+                        rowPtr = 0x00;
+                        colPtr = 0x00;
                     }
-
-                    
-                    
-                    rowPtr = 0x00;
-                    colPtr = 0x00;
                 }
 
                 TeletextCurrentField++;


### PR DESCRIPTION
Allows RAM to be accessed without interference such as this old decoder RAM test https://www.stardot.org.uk/forums/viewtopic.php?p=456093#p456093

This code continues to cycle through the various TeletextState states at the correct frame rate so that teletext sockets are serviced correctly and kept open, but does not affect the hardware flags or copy data from buffers when a source is disabled.